### PR TITLE
Suggestion to add Keccak hash algorithm to range of available algorithms

### DIFF
--- a/hashfile/__init__.py
+++ b/hashfile/__init__.py
@@ -10,6 +10,7 @@ from __future__ import print_function, unicode_literals
 import argparse
 import fileinput
 import hashlib
+import sha3
 import os
 import sys
 import zlib
@@ -38,9 +39,9 @@ def _get_available_hash_algorithms():
         available = hashlib.algorithms_available
     except AttributeError:
         try:
-            available = set(hashlib.algorithms)
+            available = set(hashlib.algorithms,sha3)
         except AttributeError:
-            available = {'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'}
+            available = {'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512','keccak_224', 'keccak_256', 'keccak_384', 'keccak_512'}
 
     aliases = {
         'sha1': {'DSA', 'DSA-SHA', 'dsaEncryption', 'dsaWithSHA', 'ecdsa-with-SHA1'}

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     keywords=['security', 'hash', 'checksum',
         'sha', 'sha1', 'md5', 'sha224', 'sha256', 'sha384', 'sha512',
         'crc32', 'adler32',
-        'md4', 'mdc2', 'ripemd160', 'whirlpool'],
+        'md4', 'mdc2', 'ripemd160', 'whirlpool' 'keccak_224', 'keccak_256', 'keccak_384', 'keccak_512']
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
These would require the pysha3 module, which contains the Keccak-related algorithms so that if a user wanted to apply those hash functions using hashfile, they would also be available. I have not tested these commits but thought to propose them for your consideration. 